### PR TITLE
update manifest_version to 3

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "Gibbon Tabs",
   "author": "Daniel Macario",
   "version": "2.0.0",
@@ -9,8 +9,9 @@
     "48": "images/logo.png",
     "128": "images/logo.png"
   },
-  "browser_action": {
-    "default_popup": "index.html" 
+  "action": {
+    "default_popup": "index.html"
   },
-  "permissions": ["tabs", "storage"]
+  "permissions": ["tabs", "storage"],
+  "host_permissions": ["<all_urls>"]
 }


### PR DESCRIPTION

The extension doesn't show up in Google :'( I forked it and when I build it, it doesn't recognize the manifest.
I updated the manifest version and build locally to keep using this wonderful extension.